### PR TITLE
Make sure clients can differentiate between API and I/O failures.

### DIFF
--- a/src/main/java/synapticloop/b2/B2ApiClient.java
+++ b/src/main/java/synapticloop/b2/B2ApiClient.java
@@ -75,7 +75,7 @@ public class B2ApiClient {
 	 * @param applicationKey the application key
 	 * @throws B2ApiException if there was an error authenticating the account
 	 */
-	public B2ApiClient(String accountId, String applicationKey) throws B2ApiException {
+	public B2ApiClient(String accountId, String applicationKey) throws B2ApiException, IOException {
 		this();
 		this.b2AuthorizeAccountResponse = authenticate(accountId, applicationKey);
 	}
@@ -110,7 +110,7 @@ public class B2ApiClient {
 	 * @return the authorize account response
 	 * @throws B2ApiException if there was an error authenticating
 	 */
-	public B2AuthorizeAccountResponse authenticate(String accountId, String applicationKey) throws B2ApiException {
+	public B2AuthorizeAccountResponse authenticate(String accountId, String applicationKey) throws B2ApiException, IOException {
 		return b2AuthorizeAccountResponse = new B2AuthorizeAccountRequest(client, accountId, applicationKey).getResponse();
 	}
 
@@ -159,7 +159,7 @@ public class B2ApiClient {
 	 * @throws B2ApiException if the bucket could not be created, of there was an
 	 *     error with the authentication
 	 */
-	public B2BucketResponse createBucket(String bucketName, BucketType bucketType) throws B2ApiException {
+	public B2BucketResponse createBucket(String bucketName, BucketType bucketType) throws B2ApiException, IOException {
 		return new B2CreateBucketRequest(client, b2AuthorizeAccountResponse, bucketName, bucketType).getResponse();
 	}
 
@@ -172,7 +172,7 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if something went wrong with the call, or the bucket was not empty
 	 */
-	public B2BucketResponse deleteBucket(String bucketId) throws B2ApiException {
+	public B2BucketResponse deleteBucket(String bucketId) throws B2ApiException, IOException {
 		return new B2DeleteBucketRequest(client, b2AuthorizeAccountResponse, bucketId).getResponse();
 	}
 
@@ -189,7 +189,7 @@ public class B2ApiClient {
 	 * @throws B2ApiException if there was an error deleting the bucket, or any
 	 *     of the enclosed files
 	 */
-	public B2BucketResponse deleteBucketFully(String bucketId) throws B2ApiException {
+	public B2BucketResponse deleteBucketFully(String bucketId) throws B2ApiException, IOException {
 		B2ListFilesResponse b2ListFilesResponse = new B2ListFileVersionsRequest(client, b2AuthorizeAccountResponse, bucketId,
 				B2RequestProperties.MAX_FILE_COUNT_RETURN).getResponse();
 		String nextFileName = b2ListFilesResponse.getNextFileName();
@@ -225,7 +225,7 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error updating the bucket
 	 */
-	public B2BucketResponse updateBucket(String bucketId, BucketType bucketType) throws B2ApiException {
+	public B2BucketResponse updateBucket(String bucketId, BucketType bucketType) throws B2ApiException, IOException {
 		return new B2UpdateBucketRequest(client, b2AuthorizeAccountResponse, bucketId, bucketType).getResponse();
 	}
 
@@ -236,7 +236,7 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if something went wrong
 	 */
-	public List<B2BucketResponse> listBuckets() throws B2ApiException {
+	public List<B2BucketResponse> listBuckets() throws B2ApiException, IOException {
 		return new B2ListBucketsRequest(client, b2AuthorizeAccountResponse).getResponse().getBuckets();
 	}
 
@@ -258,7 +258,7 @@ public class B2ApiClient {
 	 * @return the File Response
 	 * @throws B2ApiException if something went wrong
 	 */
-	public B2FileResponse getFileInfo(String fileId) throws B2ApiException {
+	public B2FileResponse getFileInfo(String fileId) throws B2ApiException, IOException {
 		return new B2GetFileInfoRequest(client, b2AuthorizeAccountResponse, fileId).getResponse();
 	}
 
@@ -273,7 +273,7 @@ public class B2ApiClient {
 	 * @throws B2ApiException if there was an error with the call
 	 */
 
-	public B2DownloadFileResponse headFileById(String fileId) throws B2ApiException {
+	public B2DownloadFileResponse headFileById(String fileId) throws B2ApiException, IOException {
 		return new B2HeadFileByIdRequest(client, b2AuthorizeAccountResponse, fileId).getResponse();
 	}
 
@@ -302,7 +302,7 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error uploading the file
 	 */
-	public B2FileResponse uploadFile(String bucketId, String fileName, HttpEntity entity, String sha1Checksum, String mimeType, Map<String, String> fileInfo) throws B2ApiException {
+	public B2FileResponse uploadFile(String bucketId, String fileName, HttpEntity entity, String sha1Checksum, String mimeType, Map<String, String> fileInfo) throws B2ApiException, IOException {
 		B2GetUploadUrlResponse b2GetUploadUrlResponse = new B2GetUploadUrlRequest(client, b2AuthorizeAccountResponse, bucketId).getResponse();
 		return new B2UploadFileRequest(client, b2AuthorizeAccountResponse, b2GetUploadUrlResponse, fileName, entity, sha1Checksum, mimeType, fileInfo).getResponse();
 	}
@@ -324,7 +324,7 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error uploading the file
 	 */
-	public B2FileResponse uploadFile(String bucketId, String fileName, File file, String mimeType, Map<String, String> fileInfo) throws B2ApiException {
+	public B2FileResponse uploadFile(String bucketId, String fileName, File file, String mimeType, Map<String, String> fileInfo) throws B2ApiException, IOException {
 		B2GetUploadUrlResponse b2GetUploadUrlResponse = new B2GetUploadUrlRequest(client, b2AuthorizeAccountResponse, bucketId).getResponse();
 		return new B2UploadFileRequest(client, b2AuthorizeAccountResponse, b2GetUploadUrlResponse, fileName, file,
 				ChecksumHelper.calculateSha1(file), mimeType, fileInfo).getResponse();
@@ -344,7 +344,7 @@ public class B2ApiClient {
 	 * @throws B2ApiException if there was an error uploading the file
 	 */
 
-	public B2FileResponse uploadFile(String bucketId, String fileName, File file, Map<String, String> fileInfo) throws B2ApiException {
+	public B2FileResponse uploadFile(String bucketId, String fileName, File file, Map<String, String> fileInfo) throws B2ApiException, IOException {
 		B2GetUploadUrlResponse b2GetUploadUrlResponse = new B2GetUploadUrlRequest(client, b2AuthorizeAccountResponse, bucketId).getResponse();
 		return new B2UploadFileRequest(client, b2AuthorizeAccountResponse, b2GetUploadUrlResponse, fileName, file,
 				ChecksumHelper.calculateSha1(file), fileInfo).getResponse();
@@ -366,7 +366,7 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error uploading the file
 	 */
-	public B2FileResponse uploadFile(String bucketId, String fileName, File file, String mimeType) throws B2ApiException {
+	public B2FileResponse uploadFile(String bucketId, String fileName, File file, String mimeType) throws B2ApiException, IOException {
 		B2GetUploadUrlResponse b2GetUploadUrlResponse = new B2GetUploadUrlRequest(client, b2AuthorizeAccountResponse, bucketId).getResponse();
 		return new B2UploadFileRequest(client, b2AuthorizeAccountResponse, b2GetUploadUrlResponse, fileName, file,
 				ChecksumHelper.calculateSha1(file), mimeType).getResponse();
@@ -385,7 +385,7 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error uploading the file
 	 */
-	public B2FileResponse uploadFile(String bucketId, String fileName, File file) throws B2ApiException {
+	public B2FileResponse uploadFile(String bucketId, String fileName, File file) throws B2ApiException, IOException {
 		B2GetUploadUrlResponse b2GetUploadUrlResponse = new B2GetUploadUrlRequest(client, b2AuthorizeAccountResponse, bucketId).getResponse();
 		return new B2UploadFileRequest(client, b2AuthorizeAccountResponse, b2GetUploadUrlResponse, fileName,
 				file, ChecksumHelper.calculateSha1(file)).getResponse();
@@ -408,7 +408,7 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error deleting the file
 	 */
-	public B2DeleteFileVersionResponse deleteFileVersion(String fileName, String fileId) throws B2ApiException {
+	public B2DeleteFileVersionResponse deleteFileVersion(String fileName, String fileId) throws B2ApiException, IOException {
 		return new B2DeleteFileVersionRequest(client, b2AuthorizeAccountResponse, fileName, fileId).getResponse();
 	}
 
@@ -422,7 +422,7 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error hiding the file
 	 */
-	public B2HideFileResponse hideFile(String bucketId, String fileName) throws B2ApiException {
+	public B2HideFileResponse hideFile(String bucketId, String fileName) throws B2ApiException, IOException {
 		return new B2HideFileRequest(client, b2AuthorizeAccountResponse, bucketId, fileName).getResponse();
 	}
 
@@ -442,7 +442,7 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error with the call
 	 */
-	public B2ListFilesResponse listFileNames(String bucketId) throws B2ApiException {
+	public B2ListFilesResponse listFileNames(String bucketId) throws B2ApiException, IOException {
 		return new B2ListFileNamesRequest(client, b2AuthorizeAccountResponse, bucketId).getResponse();
 	}
 
@@ -459,7 +459,7 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error with the call,
 	 */
-	public B2ListFilesResponse listFileNames(String bucketId, String startFileName, Integer maxFileCount) throws B2ApiException {
+	public B2ListFilesResponse listFileNames(String bucketId, String startFileName, Integer maxFileCount) throws B2ApiException, IOException {
 		return new B2ListFileNamesRequest(client, b2AuthorizeAccountResponse, bucketId, startFileName, maxFileCount).getResponse();
 	}
 
@@ -472,7 +472,7 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error with the call
 	 */
-	public B2ListFilesResponse listFileVersions(String bucketId) throws B2ApiException {
+	public B2ListFilesResponse listFileVersions(String bucketId) throws B2ApiException, IOException {
 		return new B2ListFileVersionsRequest(client, b2AuthorizeAccountResponse, bucketId, 1000).getResponse();
 	}
 
@@ -486,7 +486,7 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error with the call
 	 */
-	public B2ListFilesResponse listFileVersions(String bucketId, String startFileName) throws B2ApiException {
+	public B2ListFilesResponse listFileVersions(String bucketId, String startFileName) throws B2ApiException, IOException {
 		return new B2ListFileVersionsRequest(client, b2AuthorizeAccountResponse, bucketId, null, startFileName, null).getResponse();
 	}
 
@@ -503,7 +503,7 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error with the call
 	 */
-	public B2ListFilesResponse listFileVersions(String bucketId, String startFileName, String startFileId, Integer maxFileCount) throws B2ApiException {
+	public B2ListFilesResponse listFileVersions(String bucketId, String startFileName, String startFileId, Integer maxFileCount) throws B2ApiException, IOException {
 		return new B2ListFileVersionsRequest(client, b2AuthorizeAccountResponse, bucketId, maxFileCount, startFileName, startFileId).getResponse();
 	}
 
@@ -527,13 +527,9 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error with the call
 	 */
-	public void downloadFileByNameToFile(String bucketName, String fileName, File file) throws B2ApiException {
-		try {
-			FileUtils.copyInputStreamToFile(new B2DownloadFileByNameRequest(client, b2AuthorizeAccountResponse, bucketName, fileName)
-					.getResponse().getContent(), file);
-		} catch (IOException ex) {
-			throw new B2ApiException("Could not download to file", ex);
-		}
+	public void downloadFileByNameToFile(String bucketName, String fileName, File file) throws B2ApiException, IOException {
+		FileUtils.copyInputStreamToFile(new B2DownloadFileByNameRequest(client, b2AuthorizeAccountResponse, bucketName, fileName)
+				.getResponse().getContent(), file);
 	}
 
 	/**
@@ -557,13 +553,9 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error with the call
 	 */
-	public void downloadFileRangeByNameToFile(String bucketName, String fileName, File file, long rangeStart, long rangeEnd) throws B2ApiException {
-		try {
-			FileUtils.copyInputStreamToFile(new B2DownloadFileByNameRequest(client, b2AuthorizeAccountResponse, bucketName, fileName)
-					.getResponse().getContent(), file);
-		} catch (IOException ex) {
-			throw new B2ApiException("Could not download to file", ex);
-		}
+	public void downloadFileRangeByNameToFile(String bucketName, String fileName, File file, long rangeStart, long rangeEnd) throws B2ApiException, IOException {
+		FileUtils.copyInputStreamToFile(new B2DownloadFileByNameRequest(client, b2AuthorizeAccountResponse, bucketName, fileName)
+				.getResponse().getContent(), file);
 	}
 
 	/**
@@ -582,12 +574,8 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error with the call
 	 */
-	public byte[] downloadFileByNameToBytes(String bucketName, String fileName) throws B2ApiException {
-		try {
-			return IOUtils.toByteArray(new B2DownloadFileByNameRequest(client, b2AuthorizeAccountResponse, bucketName, fileName).getResponse().getContent());
-		} catch (IOException ex) {
-			throw new B2ApiException("Could not download to bytes", ex);
-		}
+	public byte[] downloadFileByNameToBytes(String bucketName, String fileName) throws B2ApiException, IOException {
+		return IOUtils.toByteArray(new B2DownloadFileByNameRequest(client, b2AuthorizeAccountResponse, bucketName, fileName).getResponse().getContent());
 	}
 
 	/**
@@ -611,12 +599,8 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error with the call
 	 */
-	public byte[] downloadFileRangeByNameToBytes(String bucketName, String fileName, long rangeStart, long rangeEnd) throws B2ApiException {
-		try {
-			return IOUtils.toByteArray(new B2DownloadFileByNameRequest(client, b2AuthorizeAccountResponse, bucketName, fileName, rangeStart, rangeEnd).getResponse().getContent());
-		} catch (IOException ex) {
-			throw new B2ApiException("Could not download to bytes", ex);
-		}
+	public byte[] downloadFileRangeByNameToBytes(String bucketName, String fileName, long rangeStart, long rangeEnd) throws B2ApiException, IOException {
+		return IOUtils.toByteArray(new B2DownloadFileByNameRequest(client, b2AuthorizeAccountResponse, bucketName, fileName, rangeStart, rangeEnd).getResponse().getContent());
 	}
 
 	/**
@@ -635,7 +619,7 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error with the call
 	 */
-	public InputStream downloadFileByNameToStream(String bucketName, String fileName) throws B2ApiException {
+	public InputStream downloadFileByNameToStream(String bucketName, String fileName) throws B2ApiException, IOException {
 		return new B2DownloadFileByNameRequest(client, b2AuthorizeAccountResponse, bucketName, fileName).getResponse().getContent();
 	}
 
@@ -660,7 +644,7 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error with the call
 	 */
-	public InputStream downloadFileRangeByNameToStream(String bucketName, String fileName, long rangeStart, long rangeEnd) throws B2ApiException {
+	public InputStream downloadFileRangeByNameToStream(String bucketName, String fileName, long rangeStart, long rangeEnd) throws B2ApiException, IOException {
 		return new B2DownloadFileByNameRequest(client, b2AuthorizeAccountResponse, bucketName, fileName).getResponse().getContent();
 	}
 
@@ -677,7 +661,7 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error with the call
 	 */
-	public B2DownloadFileResponse downloadFileByName(String bucketName, String fileName) throws B2ApiException {
+	public B2DownloadFileResponse downloadFileByName(String bucketName, String fileName) throws B2ApiException, IOException {
 		return new B2DownloadFileByNameRequest(client, b2AuthorizeAccountResponse, bucketName, fileName).getResponse();
 	}
 
@@ -697,7 +681,7 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error with the call
 	 */
-	public B2DownloadFileResponse downloadFileRangeByName(String bucketName, String fileName, long rangeStart, long rangeEnd) throws B2ApiException {
+	public B2DownloadFileResponse downloadFileRangeByName(String bucketName, String fileName, long rangeStart, long rangeEnd) throws B2ApiException, IOException {
 		return new B2DownloadFileByNameRequest(client, b2AuthorizeAccountResponse, bucketName, fileName, rangeStart, rangeEnd).getResponse();
 	}
 
@@ -710,7 +694,7 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error with the call
 	 */
-	public B2DownloadFileResponse downloadFileById(String fileId) throws B2ApiException {
+	public B2DownloadFileResponse downloadFileById(String fileId) throws B2ApiException, IOException {
 		return new B2DownloadFileByIdRequest(client, b2AuthorizeAccountResponse, fileId).getResponse();
 	}
 
@@ -728,7 +712,7 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error with the call
 	 */
-	public B2DownloadFileResponse downloadFileRangeById(String fileId, long rangeStart, long rangeEnd) throws B2ApiException {
+	public B2DownloadFileResponse downloadFileRangeById(String fileId, long rangeStart, long rangeEnd) throws B2ApiException, IOException {
 		return new B2DownloadFileByIdRequest(client, b2AuthorizeAccountResponse, fileId, rangeStart, rangeEnd).getResponse();
 	}
 
@@ -745,12 +729,8 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error with the call
 	 */
-	public byte[] downloadFileByIdToBytes(String fileId) throws B2ApiException {
-		try {
-			return IOUtils.toByteArray(new B2DownloadFileByIdRequest(client, b2AuthorizeAccountResponse, fileId).getResponse().getContent());
-		} catch (IOException ex) {
-			throw new B2ApiException("Could not download to bytes", ex);
-		}
+	public byte[] downloadFileByIdToBytes(String fileId) throws B2ApiException, IOException {
+		return IOUtils.toByteArray(new B2DownloadFileByIdRequest(client, b2AuthorizeAccountResponse, fileId).getResponse().getContent());
 	}
 
 	/**
@@ -771,13 +751,9 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error with the call
 	 */
-	public byte[] downloadFileRangeByIdToBytes(String fileId, long rangeStart, long rangeEnd) throws B2ApiException {
-		try {
-			return IOUtils.toByteArray(new B2DownloadFileByIdRequest(client, b2AuthorizeAccountResponse, fileId, rangeStart, rangeEnd)
-					.getResponse().getContent());
-		} catch (IOException ex) {
-			throw new B2ApiException("Could not download to bytes", ex);
-		}
+	public byte[] downloadFileRangeByIdToBytes(String fileId, long rangeStart, long rangeEnd) throws B2ApiException, IOException {
+		return IOUtils.toByteArray(new B2DownloadFileByIdRequest(client, b2AuthorizeAccountResponse, fileId, rangeStart, rangeEnd)
+				.getResponse().getContent());
 	}
 
 	/**
@@ -788,12 +764,8 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error downloading the file
 	 */
-	public void downloadFileByIdToFile(String fileId, File file) throws B2ApiException {
-		try {
-			FileUtils.copyInputStreamToFile(new B2DownloadFileByIdRequest(client, b2AuthorizeAccountResponse, fileId).getResponse().getContent(), file);
-		} catch (IOException ex) {
-			throw new B2ApiException("Could not download to file", ex);
-		}
+	public void downloadFileByIdToFile(String fileId, File file) throws B2ApiException, IOException {
+		FileUtils.copyInputStreamToFile(new B2DownloadFileByIdRequest(client, b2AuthorizeAccountResponse, fileId).getResponse().getContent(), file);
 	}
 
 	/**
@@ -809,13 +781,9 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error downloading the file
 	 */
-	public void downloadFileRangeByIdToFile(String fileId, File file, long rangeStart, long rangeEnd) throws B2ApiException {
-		try {
-			FileUtils.copyInputStreamToFile(new B2DownloadFileByIdRequest(client, b2AuthorizeAccountResponse, fileId, rangeStart, rangeEnd)
-					.getResponse().getContent(), file);
-		} catch (IOException ex) {
-			throw new B2ApiException("Could not download to file", ex);
-		}
+	public void downloadFileRangeByIdToFile(String fileId, File file, long rangeStart, long rangeEnd) throws B2ApiException, IOException {
+		FileUtils.copyInputStreamToFile(new B2DownloadFileByIdRequest(client, b2AuthorizeAccountResponse, fileId, rangeStart, rangeEnd)
+				.getResponse().getContent(), file);
 	}
 
 	/**
@@ -831,7 +799,7 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error with the call
 	 */
-	public InputStream downloadFileByIdToStream(String fileId) throws B2ApiException {
+	public InputStream downloadFileByIdToStream(String fileId) throws B2ApiException, IOException {
 		return new B2DownloadFileByIdRequest(client, b2AuthorizeAccountResponse, fileId).getResponse().getContent();
 	}
 
@@ -853,7 +821,7 @@ public class B2ApiClient {
 	 *
 	 * @throws B2ApiException if there was an error with the call
 	 */
-	public InputStream downloadFileRangeByIdToStream(String fileId, long rangeStart, long rangeEnd) throws B2ApiException {
+	public InputStream downloadFileRangeByIdToStream(String fileId, long rangeStart, long rangeEnd) throws B2ApiException, IOException {
 		return new B2DownloadFileByIdRequest(client, b2AuthorizeAccountResponse, fileId, rangeStart, rangeEnd)
 				.getResponse().getContent();
 	}

--- a/src/main/java/synapticloop/b2/exception/B2ApiException.java
+++ b/src/main/java/synapticloop/b2/exception/B2ApiException.java
@@ -25,14 +25,8 @@ public class B2ApiException extends Exception {
 	private String code;
 	private String message;
 	private int status = -1;
-	private String originalMessage;
 
-	/**
-	 * Create a new B2Api Exception
-	 */
-	public B2ApiException() {
-		super();
-	}
+	private final String json;
 
 	/**
 	 * Create a new B2 Exception with a message.  If the message is in JSON (as 
@@ -45,11 +39,12 @@ public class B2ApiException extends Exception {
 	 *   <li>message - A human-readable message, in English, saying what went wrong.</li>
 	 * </ul>
 	 * 
-	 * @param message The message of the exception
+	 * @param json The message of the exception
 	 */
-	public B2ApiException(String message) {
-		super(message);
-		parseMessage(message);
+	public B2ApiException(String json) {
+		super(json);
+		this.json = json;
+		this.parse(json);
 	}
 
 	/**
@@ -63,44 +58,28 @@ public class B2ApiException extends Exception {
 	 *   <li>message - A human-readable message, in English, saying what went wrong.</li>
 	 * </ul>
 	 * 
-	 * @param message The message of the exception
+	 * @param json The message of the exception
 	 * @param cause the root cause of the exception
 	 */
-	public B2ApiException(String message, Throwable cause) {
-		super(message, cause);
-		parseMessage(message);
+	public B2ApiException(String json, Throwable cause) {
+		super(json, cause);
+		this.json = json;
+		this.parse(json);
 	}
 
-	/**
-	 * Create a new B2Api Exception with a root cause
-	 * 
-	 * @param cause The root cause of the exception
-	 */
-	public B2ApiException(Throwable cause) {
-		super(cause);
-	}
 
-	private void parseMessage(String json) {
-		this.originalMessage = json;
+	private void parse(String json) {
+		if (null != json) {
+			try {
+				JSONObject jsonObject = new JSONObject(json);
+				this.message = jsonObject.optString("message", null);
+				this.status = jsonObject.optInt("status", -1);
+				this.code = jsonObject.optString("code", null);
 
-		if(null == json) {
-			return;
-		}
-
-		try {
-			JSONObject jsonObject = new JSONObject(json);
-
-			String tempMessage = jsonObject.getString("message");
-			if(null != tempMessage) {
-				this.message = tempMessage;
+			} catch (JSONException ex) {
+				// Ignore
+				this.message = json;
 			}
-
-			this.status = jsonObject.optInt("status");
-			this.code = jsonObject.optString("code", null);
-
-		} catch (JSONException ex) {
-			this.code = "not_json";
-			this.message = json;
 		}
 	}
 
@@ -129,8 +108,8 @@ public class B2ApiException extends Exception {
 	 * 
 	 * @return the original message text
 	 */
-	public String getOriginalMessage() { 
-		return this.originalMessage; 
+	public String getJson() {
+		return this.json;
 	}
 
 	/**

--- a/src/main/java/synapticloop/b2/request/B2AuthorizeAccountRequest.java
+++ b/src/main/java/synapticloop/b2/request/B2AuthorizeAccountRequest.java
@@ -72,12 +72,8 @@ public class B2AuthorizeAccountRequest extends BaseB2Request {
 	 * 
 	 * @throws B2ApiException if there was an error with the call
 	 */
-	public B2AuthorizeAccountResponse getResponse() throws B2ApiException {
+	public B2AuthorizeAccountResponse getResponse() throws B2ApiException, IOException {
 		final CloseableHttpResponse httpResponse = executeGet();
-		try {
-			return(new B2AuthorizeAccountResponse(EntityUtils.toString(httpResponse.getEntity())));
-		} catch(IOException e) {
-			throw new B2ApiException(e);
-		}
+		return new B2AuthorizeAccountResponse(EntityUtils.toString(httpResponse.getEntity()));
 	}
 }

--- a/src/main/java/synapticloop/b2/request/B2CreateBucketRequest.java
+++ b/src/main/java/synapticloop/b2/request/B2CreateBucketRequest.java
@@ -72,11 +72,7 @@ public class B2CreateBucketRequest extends BaseB2Request {
 	 * 
 	 * @throws B2ApiException if there was an error with the call
 	 */
-	public B2BucketResponse getResponse() throws B2ApiException {
-		try {
-			return(new B2BucketResponse(EntityUtils.toString(executePost().getEntity())));
-		} catch(IOException e) {
-			throw new B2ApiException(e);
-		}
+	public B2BucketResponse getResponse() throws B2ApiException, IOException {
+		return new B2BucketResponse(EntityUtils.toString(executePost().getEntity()));
 	}
 }

--- a/src/main/java/synapticloop/b2/request/B2DeleteBucketRequest.java
+++ b/src/main/java/synapticloop/b2/request/B2DeleteBucketRequest.java
@@ -61,11 +61,7 @@ public class B2DeleteBucketRequest extends BaseB2Request {
 	 * @throws B2ApiException if there was an error with the call, or if you are
 	 *     trying to delete a bucket which is not empty
 	 */
-	public B2BucketResponse getResponse() throws B2ApiException {
-		try {
-			return(new B2BucketResponse(EntityUtils.toString(executePost().getEntity())));
-		} catch(IOException e) {
-			throw new B2ApiException(e);
-		}
+	public B2BucketResponse getResponse() throws B2ApiException, IOException {
+		return new B2BucketResponse(EntityUtils.toString(executePost().getEntity()));
 	}
 }

--- a/src/main/java/synapticloop/b2/request/B2DeleteFileVersionRequest.java
+++ b/src/main/java/synapticloop/b2/request/B2DeleteFileVersionRequest.java
@@ -66,11 +66,7 @@ public class B2DeleteFileVersionRequest extends BaseB2Request {
 	 * 
 	 * @throws B2ApiException if there was an error with the call
 	 */
-	public B2DeleteFileVersionResponse getResponse() throws B2ApiException {
-		try {
-			return(new B2DeleteFileVersionResponse(EntityUtils.toString(executePost().getEntity())));
-		} catch(IOException e) {
-			throw new B2ApiException(e);
-		}
+	public B2DeleteFileVersionResponse getResponse() throws B2ApiException, IOException {
+		return new B2DeleteFileVersionResponse(EntityUtils.toString(executePost().getEntity()));
 	}
 }

--- a/src/main/java/synapticloop/b2/request/B2DownloadFileByIdRequest.java
+++ b/src/main/java/synapticloop/b2/request/B2DownloadFileByIdRequest.java
@@ -23,6 +23,8 @@ import synapticloop.b2.exception.B2ApiException;
 import synapticloop.b2.response.B2AuthorizeAccountResponse;
 import synapticloop.b2.response.B2DownloadFileResponse;
 
+import java.io.IOException;
+
 /**
  * <p>Downloads one file from B2.</p>
  * 
@@ -112,7 +114,7 @@ public class B2DownloadFileByIdRequest extends BaseB2Request {
 	 * @return The download file response
 	 * @throws B2ApiException If there was an error with the call
 	 */
-	public B2DownloadFileResponse getResponse() throws B2ApiException {
-		return (new B2DownloadFileResponse(executeGet()));
+	public B2DownloadFileResponse getResponse() throws B2ApiException, IOException {
+		return new B2DownloadFileResponse(executeGet());
 	}
 }

--- a/src/main/java/synapticloop/b2/request/B2DownloadFileByNameRequest.java
+++ b/src/main/java/synapticloop/b2/request/B2DownloadFileByNameRequest.java
@@ -24,6 +24,8 @@ import synapticloop.b2.response.B2AuthorizeAccountResponse;
 import synapticloop.b2.response.B2DownloadFileResponse;
 import synapticloop.b2.util.URLEncoder;
 
+import java.io.IOException;
+
 /**
  * <p>Downloads one file by providing the name of the bucket and the name of the file.</p>
  * 
@@ -91,7 +93,7 @@ public class B2DownloadFileByNameRequest extends BaseB2Request {
 	 * 
 	 * @throws B2ApiException If there was an error with the call
 	 */
-	public B2DownloadFileResponse getResponse() throws B2ApiException {
-		return(new B2DownloadFileResponse(executeGet()));
+	public B2DownloadFileResponse getResponse() throws B2ApiException, IOException {
+		return new B2DownloadFileResponse(executeGet());
 	}
 }

--- a/src/main/java/synapticloop/b2/request/B2GetFileInfoRequest.java
+++ b/src/main/java/synapticloop/b2/request/B2GetFileInfoRequest.java
@@ -62,11 +62,7 @@ public class B2GetFileInfoRequest extends BaseB2Request {
 	 * 
 	 * @throws B2ApiException if there was an error with the call
 	 */
-	public B2FileResponse getResponse() throws B2ApiException {
-		try {
-			return(new B2FileResponse(EntityUtils.toString(executePost().getEntity())));
-		} catch(IOException e) {
-			throw new B2ApiException(e);
-		}
+	public B2FileResponse getResponse() throws B2ApiException, IOException {
+		return new B2FileResponse(EntityUtils.toString(executePost().getEntity()));
 	}
 }

--- a/src/main/java/synapticloop/b2/request/B2GetUploadUrlRequest.java
+++ b/src/main/java/synapticloop/b2/request/B2GetUploadUrlRequest.java
@@ -61,11 +61,7 @@ public class B2GetUploadUrlRequest extends BaseB2Request {
 	 * 
 	 * @throws B2ApiException if something went wrong
 	 */
-	public B2GetUploadUrlResponse getResponse() throws B2ApiException {
-		try {
-			return(new B2GetUploadUrlResponse(EntityUtils.toString(executePost().getEntity())));
-		} catch(IOException e) {
-			throw new B2ApiException(e);
-		}
+	public B2GetUploadUrlResponse getResponse() throws B2ApiException, IOException {
+		return new B2GetUploadUrlResponse(EntityUtils.toString(executePost().getEntity()));
 	}
 }

--- a/src/main/java/synapticloop/b2/request/B2HeadFileByIdRequest.java
+++ b/src/main/java/synapticloop/b2/request/B2HeadFileByIdRequest.java
@@ -22,6 +22,8 @@ import synapticloop.b2.exception.B2ApiException;
 import synapticloop.b2.response.B2AuthorizeAccountResponse;
 import synapticloop.b2.response.B2DownloadFileResponse;
 
+import java.io.IOException;
+
 /**
  * <p>Gets information on one file from B2.</p>
  * 
@@ -76,7 +78,7 @@ public class B2HeadFileByIdRequest extends BaseB2Request {
 	 * 
 	 * @throws B2ApiException if something went wrong
 	 */
-	public B2DownloadFileResponse getResponse() throws B2ApiException {
-		return(new B2DownloadFileResponse(this.executeHead()));
+	public B2DownloadFileResponse getResponse() throws B2ApiException, IOException {
+		return new B2DownloadFileResponse(this.executeHead());
 	}
 }

--- a/src/main/java/synapticloop/b2/request/B2HideFileRequest.java
+++ b/src/main/java/synapticloop/b2/request/B2HideFileRequest.java
@@ -59,11 +59,7 @@ public class B2HideFileRequest extends BaseB2Request {
 	 * 
 	 * @throws B2ApiException if something went wrong
 	 */
-	public B2HideFileResponse getResponse() throws B2ApiException {
-		try {
-			return(new B2HideFileResponse(EntityUtils.toString(executePost().getEntity())));
-		} catch(IOException e) {
-			throw new B2ApiException(e);
-		}
+	public B2HideFileResponse getResponse() throws B2ApiException, IOException {
+		return new B2HideFileResponse(EntityUtils.toString(executePost().getEntity()));
 	}
 }

--- a/src/main/java/synapticloop/b2/request/B2ListBucketsRequest.java
+++ b/src/main/java/synapticloop/b2/request/B2ListBucketsRequest.java
@@ -57,12 +57,7 @@ public class B2ListBucketsRequest extends BaseB2Request {
 	 * 
 	 * @throws B2ApiException if something went wrong
 	 */
-	public B2ListBucketsResponse getResponse() throws B2ApiException {
-		try {
-			return new B2ListBucketsResponse(EntityUtils.toString(executePost().getEntity()));
-		} catch(IOException e) {
-			throw new B2ApiException(e);
-		}
+	public B2ListBucketsResponse getResponse() throws B2ApiException, IOException {
+		return new B2ListBucketsResponse(EntityUtils.toString(executePost().getEntity()));
 	}
-
 }

--- a/src/main/java/synapticloop/b2/request/B2ListFileNamesRequest.java
+++ b/src/main/java/synapticloop/b2/request/B2ListFileNamesRequest.java
@@ -101,11 +101,7 @@ public class B2ListFileNamesRequest extends BaseB2Request {
 	 * 
 	 * @throws B2ApiException if something went wrong
 	 */
-	public B2ListFilesResponse getResponse() throws B2ApiException {
-		try {
-			return(new B2ListFilesResponse(EntityUtils.toString(executePost().getEntity())));
-		} catch(IOException e) {
-			throw new B2ApiException(e);
-		}
+	public B2ListFilesResponse getResponse() throws B2ApiException, IOException {
+		return new B2ListFilesResponse(EntityUtils.toString(executePost().getEntity()));
 	}
 }

--- a/src/main/java/synapticloop/b2/request/B2ListFileVersionsRequest.java
+++ b/src/main/java/synapticloop/b2/request/B2ListFileVersionsRequest.java
@@ -109,11 +109,7 @@ public class B2ListFileVersionsRequest extends BaseB2Request {
 	 * 
 	 * @throws B2ApiException if something went wrong
 	 */
-	public B2ListFilesResponse getResponse() throws B2ApiException {
-		try {
-			return new B2ListFilesResponse(EntityUtils.toString(executePost().getEntity()));
-		} catch(IOException e) {
-			throw new B2ApiException(e);
-		}
+	public B2ListFilesResponse getResponse() throws B2ApiException, IOException {
+		return new B2ListFilesResponse(EntityUtils.toString(executePost().getEntity()));
 	}
 }

--- a/src/main/java/synapticloop/b2/request/B2UpdateBucketRequest.java
+++ b/src/main/java/synapticloop/b2/request/B2UpdateBucketRequest.java
@@ -65,11 +65,7 @@ public class B2UpdateBucketRequest extends BaseB2Request {
 	 * 
 	 * @throws B2ApiException if something went wrong
 	 */
-	public B2BucketResponse getResponse() throws B2ApiException {
-		try {
-			return(new B2BucketResponse(EntityUtils.toString(executePost().getEntity())));
-		} catch(IOException e) {
-			throw new B2ApiException(e);
-		}
+	public B2BucketResponse getResponse() throws B2ApiException, IOException {
+		return new B2BucketResponse(EntityUtils.toString(executePost().getEntity()));
 	}
 }

--- a/src/main/java/synapticloop/b2/request/B2UploadFileRequest.java
+++ b/src/main/java/synapticloop/b2/request/B2UploadFileRequest.java
@@ -205,11 +205,7 @@ public class B2UploadFileRequest extends BaseB2Request {
 	 * @throws B2ApiException if something went wrong
 	 */
 
-	public B2FileResponse getResponse() throws B2ApiException {
-		try {
-			return new B2FileResponse(EntityUtils.toString(executePost(entity).getEntity()));
-		} catch(IOException e) {
-			throw new B2ApiException(e);
-		}
+	public B2FileResponse getResponse() throws B2ApiException, IOException {
+		return new B2FileResponse(EntityUtils.toString(executePost(entity).getEntity()));
 	}
 }

--- a/src/main/java/synapticloop/b2/request/BaseB2Request.java
+++ b/src/main/java/synapticloop/b2/request/BaseB2Request.java
@@ -16,22 +16,11 @@ package synapticloop.b2.request;
  * this source code or binaries.
  */
 
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpResponseException;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.*;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -40,9 +29,15 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import synapticloop.b2.exception.B2ApiException;
 import synapticloop.b2.response.B2AuthorizeAccountResponse;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 public abstract class BaseB2Request {
 	private static final Logger LOGGER = LoggerFactory.getLogger(BaseB2Request.class);
@@ -148,53 +143,45 @@ public abstract class BaseB2Request {
 	 * 
 	 * @throws B2ApiException if something went wrong with the call
 	 */
-	protected CloseableHttpResponse executeHead() throws B2ApiException {
-		try {
-			URI uri = this.buildUri();
+	protected CloseableHttpResponse executeHead() throws B2ApiException, IOException {
+		URI uri = this.buildUri();
 
-			LOGGER.debug("HEAD request to URL '{}'", uri.toString());
+		LOGGER.debug("HEAD request to URL '{}'", uri.toString());
 
-			HttpHead httpHead = new HttpHead(uri);
+		HttpHead httpHead = new HttpHead(uri);
 
-			CloseableHttpResponse httpResponse = this.execute(httpHead);
+		CloseableHttpResponse httpResponse = this.execute(httpHead);
 
-			switch(httpResponse.getStatusLine().getStatusCode()) {
+		switch(httpResponse.getStatusLine().getStatusCode()) {
 			case HttpStatus.SC_OK:
 				return httpResponse;
-			}
-			throw new B2ApiException(EntityUtils.toString(httpResponse.getEntity()), new HttpResponseException(
-					httpResponse.getStatusLine().getStatusCode(), httpResponse.getStatusLine().getReasonPhrase()));
-		} catch (IOException | URISyntaxException ex) {
-			throw new B2ApiException(ex);
 		}
+		throw new B2ApiException(EntityUtils.toString(httpResponse.getEntity()), new HttpResponseException(
+				httpResponse.getStatusLine().getStatusCode(), httpResponse.getStatusLine().getReasonPhrase()));
 	}
 
 	/**
 	 * Execute a GET request, returning the data stream from the response.
 	 * 
 	 * @return The response from the GET request
-	 * 
+	 *
 	 * @throws B2ApiException if there was an error with the request
 	 */
-	protected CloseableHttpResponse executeGet() throws B2ApiException {
-		try {
-			URI uri = this.buildUri();
+	protected CloseableHttpResponse executeGet() throws B2ApiException, IOException {
+		URI uri = this.buildUri();
 
-			HttpGet httpGet = new HttpGet(uri);
+		HttpGet httpGet = new HttpGet(uri);
 
-			CloseableHttpResponse httpResponse = this.execute(httpGet);
+		CloseableHttpResponse httpResponse = this.execute(httpGet);
 
-			// you will either get an OK or a partial content
-			switch(httpResponse.getStatusLine().getStatusCode()) {
+		// you will either get an OK or a partial content
+		switch(httpResponse.getStatusLine().getStatusCode()) {
 			case HttpStatus.SC_OK:
 			case HttpStatus.SC_PARTIAL_CONTENT:
 				return httpResponse;
-			}
-			throw new B2ApiException(EntityUtils.toString(httpResponse.getEntity()), new HttpResponseException(
-					httpResponse.getStatusLine().getStatusCode(), httpResponse.getStatusLine().getReasonPhrase()));
-		} catch (IOException | URISyntaxException ex) {
-			throw new B2ApiException(ex);
 		}
+		throw new B2ApiException(EntityUtils.toString(httpResponse.getEntity()), new HttpResponseException(
+				httpResponse.getStatusLine().getStatusCode(), httpResponse.getStatusLine().getReasonPhrase()));
 	}
 
 	/**
@@ -205,25 +192,21 @@ public abstract class BaseB2Request {
 	 * @throws B2ApiException if there was an error with the call, most notably
 	 *     a non OK status code (i.e. not 200)
 	 */
-	protected CloseableHttpResponse executePost() throws B2ApiException {
-		try {
-			URI uri = this.buildUri();
+	protected CloseableHttpResponse executePost() throws B2ApiException, IOException {
+		URI uri = this.buildUri();
 
-			String postData = convertPostData();
-			HttpPost httpPost = new HttpPost(uri);
+		String postData = convertPostData();
+		HttpPost httpPost = new HttpPost(uri);
 
-			httpPost.setEntity(new StringEntity(postData));
-			CloseableHttpResponse httpResponse = this.execute(httpPost);
+		httpPost.setEntity(new StringEntity(postData));
+		CloseableHttpResponse httpResponse = this.execute(httpPost);
 
-			switch(httpResponse.getStatusLine().getStatusCode()) {
+		switch(httpResponse.getStatusLine().getStatusCode()) {
 			case HttpStatus.SC_OK:
 				return httpResponse;
-			}
-			throw new B2ApiException(EntityUtils.toString(httpResponse.getEntity()), 
-					new HttpResponseException(httpResponse.getStatusLine().getStatusCode(), httpResponse.getStatusLine().getReasonPhrase()));
-		} catch (IOException | URISyntaxException ex) {
-			throw new B2ApiException(ex);
 		}
+		throw new B2ApiException(EntityUtils.toString(httpResponse.getEntity()), new HttpResponseException(
+				httpResponse.getStatusLine().getStatusCode(), httpResponse.getStatusLine().getReasonPhrase()));
 	}
 
 	/**
@@ -236,24 +219,20 @@ public abstract class BaseB2Request {
 	 * @throws B2ApiException if there was an error with the call, most notably
 	 *     a non OK status code (i.e. not 200)
 	 */
-	protected CloseableHttpResponse executePost(HttpEntity entity) throws B2ApiException {
-		try {
-			URI uri = this.buildUri();
+	protected CloseableHttpResponse executePost(HttpEntity entity) throws B2ApiException, IOException {
+		URI uri = this.buildUri();
 
-			HttpPost httpPost = new HttpPost(uri);
+		HttpPost httpPost = new HttpPost(uri);
 
-			httpPost.setEntity(entity);
-			CloseableHttpResponse httpResponse = this.execute(httpPost);
+		httpPost.setEntity(entity);
+		CloseableHttpResponse httpResponse = this.execute(httpPost);
 
-			switch(httpResponse.getStatusLine().getStatusCode()) {
+		switch(httpResponse.getStatusLine().getStatusCode()) {
 			case HttpStatus.SC_OK:
 				return httpResponse;
-			}
-			throw new B2ApiException(EntityUtils.toString(httpResponse.getEntity()), new HttpResponseException(
-					httpResponse.getStatusLine().getStatusCode(), httpResponse.getStatusLine().getReasonPhrase()));
-		} catch (IOException | URISyntaxException ex) {
-			throw new B2ApiException(ex);
 		}
+		throw new B2ApiException(EntityUtils.toString(httpResponse.getEntity()), new HttpResponseException(
+				httpResponse.getStatusLine().getStatusCode(), httpResponse.getStatusLine().getReasonPhrase()));
 	}
 
 	/**
@@ -262,9 +241,9 @@ public abstract class BaseB2Request {
 	 * 
 	 * @return the JSON string of the data
 	 * 
-	 * @throws B2ApiException if there was an error converting the data.
+	 * @throws IOException if there was an error converting the data.
 	 */
-	protected String convertPostData() throws B2ApiException {
+	protected String convertPostData() throws IOException {
 		JSONObject jsonObject = new JSONObject();
 
 		for(final String key : requestBodyData.keySet()) {
@@ -272,7 +251,7 @@ public abstract class BaseB2Request {
 				LOGGER.debug("Setting key '{}' to value '{}'", key, obfuscateData(key, requestBodyData.get(key)));
 				jsonObject.put(key, requestBodyData.get(key));
 			} catch(JSONException ex) {
-				throw new B2ApiException(ex);
+				throw new IOException(ex);
 			}
 		}
 		return jsonObject.toString();
@@ -284,16 +263,21 @@ public abstract class BaseB2Request {
 	 * 
 	 * @return The URI for this request, with properly encoded parameters
 	 * 
-	 * @throws URISyntaxException If there was an error building the URI
+	 * @throws IOException If there was an error building the URI
 	 */
-	protected URI buildUri() throws URISyntaxException {
-		URIBuilder uriBuilder = new URIBuilder(url);
+	protected URI buildUri() throws IOException {
+		try {
+			URIBuilder uriBuilder = new URIBuilder(url);
 
-		for(final String key : requestParameters.keySet()) {
-			uriBuilder.addParameter(key, requestParameters.get(key));
+			for (final String key : requestParameters.keySet()) {
+				uriBuilder.addParameter(key, requestParameters.get(key));
+			}
+
+			return uriBuilder.build();
 		}
-
-		return uriBuilder.build();
+		catch(URISyntaxException e) {
+			throw new IOException(e);
+		}
 	}
 
 	/**

--- a/src/main/java/synapticloop/b2/response/BaseB2Response.java
+++ b/src/main/java/synapticloop/b2/response/BaseB2Response.java
@@ -1,5 +1,6 @@
 package synapticloop.b2.response;
 
+import java.io.IOException;
 import java.util.Iterator;
 
 /*
@@ -61,7 +62,7 @@ public abstract class BaseB2Response {
 		try {
 			jsonObject = new JSONObject(json);
 		} catch (JSONException ex) {
-			throw new B2ApiException(ex);
+			throw new B2ApiException(json, ex);
 		}
 		return jsonObject;
 	}

--- a/src/main/java/synapticloop/b2/util/ChecksumHelper.java
+++ b/src/main/java/synapticloop/b2/util/ChecksumHelper.java
@@ -32,14 +32,14 @@ public class ChecksumHelper {
 	 *
 	 * @return the sha1 of the file
 	 *
-	 * @throws B2ApiException if something went wrong with the calculation
+	 * @throws IOException if something went wrong with the calculation
 	 */
-	public static String calculateSha1(File file) throws B2ApiException {
+	public static String calculateSha1(File file) throws IOException {
 		try {
 			return calculateSha1(new FileInputStream(file));
 		}
 		catch(FileNotFoundException e) {
-			throw new B2ApiException(e);
+			throw new IOException(e);
 		}
 	}
 
@@ -50,9 +50,9 @@ public class ChecksumHelper {
 	 *
 	 * @return the sha1 sum
 	 *
-	 * @throws B2ApiException if there was an error calculating the sha1 sum
+	 * @throws IOException if there was an error calculating the sha1 sum
 	 */
-	public static String calculateSha1(InputStream in) throws B2ApiException {
+	public static String calculateSha1(InputStream in) throws IOException {
 
 		MessageDigest messageDigest;
 		InputStream inputStream = null;
@@ -68,8 +68,8 @@ public class ChecksumHelper {
 			}
 
 			return(new HexBinaryAdapter().marshal(messageDigest.digest()));
-		} catch (NoSuchAlgorithmException | IOException ex) {
-			throw new B2ApiException(ex);
+		} catch (NoSuchAlgorithmException ex) {
+			throw new IOException(ex);
 		} finally {
 			IOUtils.closeQuietly(inputStream);
 		}

--- a/src/test/java/synapticloop/b2/B2ClientTest.java
+++ b/src/test/java/synapticloop/b2/B2ClientTest.java
@@ -41,7 +41,7 @@ public class B2ClientTest {
 	}
 
 	@Test
-	public void testPrivateBuckets() throws B2ApiException {
+	public void testPrivateBuckets() throws Exception {
 		B2BucketResponse createPrivateBucket = client.createBucket(B2TestHelper.B2_BUCKET_PREFIX + UUID.randomUUID().toString(), BucketType.allPrivate);
 
 		B2BucketResponse updateBucket = client.updateBucket(createPrivateBucket.getBucketId(), BucketType.allPublic);
@@ -51,7 +51,7 @@ public class B2ClientTest {
 	}
 
 	@Test
-	public void testPublicBuckets() throws B2ApiException {
+	public void testPublicBuckets() throws Exception {
 		B2BucketResponse createPublicBucket = client.createBucket(B2TestHelper.B2_BUCKET_PREFIX + UUID.randomUUID().toString(), BucketType.allPublic);
 		client.deleteBucket(createPublicBucket.getBucketId());
 	}

--- a/src/test/java/synapticloop/b2/DeleteTestBuckets.java
+++ b/src/test/java/synapticloop/b2/DeleteTestBuckets.java
@@ -9,7 +9,7 @@ import synapticloop.b2.response.B2FileInfoResponse;
 
 public class DeleteTestBuckets {
 
-	public static void main(String[] args) throws B2ApiException {
+	public static void main(String[] args) throws Exception {
 		String b2AccountId = System.getenv(B2TestHelper.B2_ACCOUNT_ID);
 		String b2ApplicationKey = System.getenv(B2TestHelper.B2_APPLICATION_KEY);
 

--- a/src/test/java/synapticloop/b2/exception/B2ExceptionTest.java
+++ b/src/test/java/synapticloop/b2/exception/B2ExceptionTest.java
@@ -7,22 +7,22 @@ import org.junit.Test;
 
 
 public class B2ExceptionTest {
-	private B2ApiException b2Exception = null;
-
-	@Before
-	public void setup() {
-		b2Exception = new B2ApiException();
-	}
 
 	@Test
 	public void testEmptyException() {
-		b2Exception = new B2ApiException("");
+		B2ApiException b2Exception = new B2ApiException("");
 		assertEquals("", b2Exception.getMessage());
 	}
 
 	@Test
+	public void testNullResponseException() {
+		B2ApiException b2Exception = new B2ApiException((String)null);
+		assertEquals(null, b2Exception.getMessage());
+	}
+
+	@Test
 	public void testJsonException() {
-		b2Exception = new B2ApiException("{\n" +
+		B2ApiException b2Exception = new B2ApiException("{\n" +
 				"      \"code\": \"bad_json\",\n" + 
 				"      \"message\": \"unknown field in com.backblaze.modules.b2.data.FileNameAndId: accountId\",\n" + 
 				"      \"status\": 400\n" + 

--- a/src/test/java/synapticloop/b2/helper/B2TestHelper.java
+++ b/src/test/java/synapticloop/b2/helper/B2TestHelper.java
@@ -22,7 +22,7 @@ public class B2TestHelper {
 
 	private static B2AuthorizeAccountResponse response = null;
 
-	public static B2AuthorizeAccountResponse getB2AuthorizeAccountResponse() throws B2ApiException {
+	public static B2AuthorizeAccountResponse getB2AuthorizeAccountResponse() throws Exception {
 
 		if(null == response) {
 			boolean isOK = true;
@@ -57,7 +57,7 @@ public class B2TestHelper {
 	 * 
 	 * @throws B2ApiException if there was an error with the creation of the bucket
 	 */
-	public static B2BucketResponse createRandomPrivateBucket() throws B2ApiException {
+	public static B2BucketResponse createRandomPrivateBucket() throws Exception {
 		B2CreateBucketRequest b2CreateBucketRequest = new B2CreateBucketRequest(HttpClients.createDefault(), getB2AuthorizeAccountResponse(), B2_BUCKET_PREFIX + UUID.randomUUID().toString(), BucketType.allPrivate);
 		return(b2CreateBucketRequest.getResponse());
 	}
@@ -71,7 +71,7 @@ public class B2TestHelper {
 	 * 
 	 * @throws B2ApiException if there was an error with the creation of the bucket
 	 */
-	public static B2BucketResponse createRandomPublicBucket() throws B2ApiException {
+	public static B2BucketResponse createRandomPublicBucket() throws Exception {
 		B2CreateBucketRequest b2CreateBucketRequest = new B2CreateBucketRequest(HttpClients.createDefault(), getB2AuthorizeAccountResponse(), B2_BUCKET_PREFIX + UUID.randomUUID().toString(), BucketType.allPublic);
 		return(b2CreateBucketRequest.getResponse());
 	}
@@ -85,16 +85,16 @@ public class B2TestHelper {
 	 * 
 	 * @throws B2ApiException if something went wrong
 	 */
-	public static B2BucketResponse deleteBucket(String bucketId) throws B2ApiException {
+	public static B2BucketResponse deleteBucket(String bucketId) throws Exception {
 		B2DeleteBucketRequest b2DeleteBucketRequest = new B2DeleteBucketRequest(HttpClients.createDefault(), getB2AuthorizeAccountResponse(), bucketId);
 		return(b2DeleteBucketRequest.getResponse());
 	}
 
-	public static B2GetUploadUrlResponse getUploadUrl(String bucketId) throws B2ApiException {
+	public static B2GetUploadUrlResponse getUploadUrl(String bucketId) throws Exception {
 		return(new B2GetUploadUrlRequest(HttpClients.createDefault(), B2TestHelper.getB2AuthorizeAccountResponse(), bucketId).getResponse());
 	}
 
-	public static B2DeleteFileVersionResponse deleteFile(String fileName, String fileId) throws B2ApiException {
+	public static B2DeleteFileVersionResponse deleteFile(String fileName, String fileId) throws Exception {
 		return(new B2DeleteFileVersionRequest(HttpClients.createDefault(), getB2AuthorizeAccountResponse(), fileName, fileId).getResponse());
 	}
 
@@ -107,19 +107,15 @@ public class B2TestHelper {
 	 * 
 	 * @throws B2ApiException if something went wrong
 	 */
-	public static B2FileResponse uploadTemporaryFileToBucket(String bucketId) throws B2ApiException {
+	public static B2FileResponse uploadTemporaryFileToBucket(String bucketId) throws Exception {
 		B2GetUploadUrlResponse b2GetUploadUrlResponse = getUploadUrl(bucketId);
-		File file = null;
-		try {
-			file = File.createTempFile("test/path/backblaze-api-test", ".txt");
-			FileWriter fileWriter = new FileWriter(file);
-			fileWriter.write(DUMMY_FILE_CONTENT);
-			fileWriter.flush();
-			fileWriter.close();
-			file.deleteOnExit();
-		} catch(IOException ioex) {
-			throw new B2ApiException("Could not create temporary file", ioex);
-		}
+		File file;
+		file = File.createTempFile("test/path/backblaze-api-test", ".txt");
+		FileWriter fileWriter = new FileWriter(file);
+		fileWriter.write(DUMMY_FILE_CONTENT);
+		fileWriter.flush();
+		fileWriter.close();
+		file.deleteOnExit();
 		return(new B2UploadFileRequest(HttpClients.createDefault(), getB2AuthorizeAccountResponse(),
 				b2GetUploadUrlResponse, file.getName(), file, ChecksumHelper.calculateSha1(file)).getResponse());
 	}
@@ -149,19 +145,15 @@ public class B2TestHelper {
 	 * 
 	 * @throws B2ApiException if something went wrong
 	 */
-	public static B2FileResponse uploadTemporaryFileToBucket(String bucketId, Map<String, String> fileInfo) throws B2ApiException {
+	public static B2FileResponse uploadTemporaryFileToBucket(String bucketId, Map<String, String> fileInfo) throws Exception {
 		B2GetUploadUrlResponse b2GetUploadUrlResponse = getUploadUrl(bucketId);
-		File file = null;
-		try {
-			file = File.createTempFile("backblaze-api-test", ".txt");
-			FileWriter fileWriter = new FileWriter(file);
-			fileWriter.write(DUMMY_FILE_CONTENT);
-			fileWriter.flush();
-			fileWriter.close();
-			file.deleteOnExit();
-		} catch(IOException ioex) {
-			throw new B2ApiException("Could not create temporary file", ioex);
-		}
+		File file;
+		file = File.createTempFile("backblaze-api-test", ".txt");
+		FileWriter fileWriter = new FileWriter(file);
+		fileWriter.write(DUMMY_FILE_CONTENT);
+		fileWriter.flush();
+		fileWriter.close();
+		file.deleteOnExit();
 		return(new B2UploadFileRequest(HttpClients.createDefault(), getB2AuthorizeAccountResponse(), b2GetUploadUrlResponse, file.getName(), file,
 				ChecksumHelper.calculateSha1(file), fileInfo).getResponse());
 	}

--- a/src/test/java/synapticloop/b2/request/B2AuthorizeAccountRequestTest.java
+++ b/src/test/java/synapticloop/b2/request/B2AuthorizeAccountRequestTest.java
@@ -20,7 +20,7 @@ public class B2AuthorizeAccountRequestTest {
 	}
 
 	@Test
-	public void testCorrectCredentials() throws B2ApiException {
+	public void testCorrectCredentials() throws Exception {
 		boolean isOK = true;
 		String b2AccountId = System.getenv(B2_ACCOUNT_ID);
 		String b2ApplicationKey = System.getenv(B2_APPLICATION_KEY);
@@ -48,7 +48,7 @@ public class B2AuthorizeAccountRequestTest {
 	}
 
 	@Test (expected=B2ApiException.class)
-	public void testIncorrectCredentials() throws B2ApiException {
+	public void testIncorrectCredentials() throws Exception {
 		B2AuthorizeAccountRequest b2AuthorizeAccountRequest = new B2AuthorizeAccountRequest(HttpClients.createDefault(), "bad", "value");
 		b2AuthorizeAccountRequest.getResponse();
 	}

--- a/src/test/java/synapticloop/b2/request/B2CreateAndDeleteBucketRequestTest.java
+++ b/src/test/java/synapticloop/b2/request/B2CreateAndDeleteBucketRequestTest.java
@@ -20,13 +20,13 @@ public class B2CreateAndDeleteBucketRequestTest {
 	private static String bucketName = null;
 
 	@BeforeClass
-	public static void setupBeforClass() throws B2ApiException {
+	public static void setupBeforClass() throws Exception {
 		b2AuthorizeAccountResponse = B2TestHelper.getB2AuthorizeAccountResponse();
 		bucketName = UUID.randomUUID().toString();
 	}
 
 	@Test
-	public void testBucketCreationAndDeletion() throws B2ApiException {
+	public void testBucketCreationAndDeletion() throws Exception {
 
 		b2CreateBucketRequest = new B2CreateBucketRequest(HttpClients.createDefault(), b2AuthorizeAccountResponse, bucketName, BucketType.allPrivate);
 		B2BucketResponse b2BucketResponse = b2CreateBucketRequest.getResponse();

--- a/src/test/java/synapticloop/b2/request/B2DeleteFileVersionRequestTest.java
+++ b/src/test/java/synapticloop/b2/request/B2DeleteFileVersionRequestTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.assertNotNull;
 public class B2DeleteFileVersionRequestTest {
 
 	@Test
-	public void testDeleteFileVersion() throws B2ApiException {
+	public void testDeleteFileVersion() throws Exception {
 		B2AuthorizeAccountResponse b2AuthorizeAccountResponse = B2TestHelper.getB2AuthorizeAccountResponse();
 		B2BucketResponse b2BucketResponse = B2TestHelper.createRandomPrivateBucket();
 		B2FileResponse b2FileResponseIn = B2TestHelper.uploadTemporaryFileToBucket(b2BucketResponse.getBucketId());
@@ -33,22 +33,18 @@ public class B2DeleteFileVersionRequestTest {
 	}
 
 	@Test
-	public void testDeleteFileVersionWithWhitespace() throws B2ApiException {
+	public void testDeleteFileVersionWithWhitespace() throws Exception {
 		B2AuthorizeAccountResponse b2AuthorizeAccountResponse = B2TestHelper.getB2AuthorizeAccountResponse();
 		B2BucketResponse b2BucketResponse = B2TestHelper.createRandomPrivateBucket();
 
 		B2GetUploadUrlResponse b2GetUploadUrlResponse = B2TestHelper.getUploadUrl(b2BucketResponse.getBucketId());
 		File file;
-		try {
-			file = File.createTempFile("test/path/backblaze-api-test whitespace", ".txt");
-			FileWriter fileWriter = new FileWriter(file);
-			fileWriter.write("hello whitespace!");
-			fileWriter.flush();
-			fileWriter.close();
-			file.deleteOnExit();
-		} catch(IOException ioex) {
-			throw new B2ApiException("Could not create temporary file", ioex);
-		}
+		file = File.createTempFile("test/path/backblaze-api-test whitespace", ".txt");
+		FileWriter fileWriter = new FileWriter(file);
+		fileWriter.write("hello whitespace!");
+		fileWriter.flush();
+		fileWriter.close();
+		file.deleteOnExit();
 		final CloseableHttpClient client = HttpClients.createDefault();
 		final B2FileResponse b2FileResponseIn = new B2UploadFileRequest(client, b2AuthorizeAccountResponse,
 				b2GetUploadUrlResponse, file.getName(), file, ChecksumHelper.calculateSha1(file)).getResponse();

--- a/src/test/java/synapticloop/b2/request/B2DownloadFileRequestTest.java
+++ b/src/test/java/synapticloop/b2/request/B2DownloadFileRequestTest.java
@@ -56,7 +56,7 @@ public class B2DownloadFileRequestTest {
 	}
 
 	@Test
-	public void testDownloadFileBy() throws B2ApiException, IOException {
+	public void testDownloadFileBy() throws Exception {
 		randomPrivateBucket = B2TestHelper.createRandomPrivateBucket();
 		b2FileResponse = B2TestHelper.uploadTemporaryFileToBucket(randomPrivateBucket.getBucketId());
 
@@ -71,7 +71,7 @@ public class B2DownloadFileRequestTest {
 	}
 
 	@Test
-	public void testDownloadFileByRange() throws B2ApiException, IOException {
+	public void testDownloadFileByRange() throws Exception {
 		randomPrivateBucket = B2TestHelper.createRandomPrivateBucket();
 		b2FileResponse = B2TestHelper.uploadTemporaryFileToBucket(randomPrivateBucket.getBucketId());
 

--- a/src/test/java/synapticloop/b2/request/B2GetFileInfoRequestTest.java
+++ b/src/test/java/synapticloop/b2/request/B2GetFileInfoRequestTest.java
@@ -14,7 +14,7 @@ import synapticloop.b2.response.B2FileResponse;
 public class B2GetFileInfoRequestTest {
 
 	@Test
-	public void testGetFileInfo() throws B2ApiException {
+	public void testGetFileInfo() throws Exception {
 		B2AuthorizeAccountResponse b2AuthorizeAccountResponse = B2TestHelper.getB2AuthorizeAccountResponse();
 		B2BucketResponse b2BucketResponse = B2TestHelper.createRandomPrivateBucket();
 		B2FileResponse b2FileResponseIn = B2TestHelper.uploadTemporaryFileToBucket(b2BucketResponse.getBucketId());

--- a/src/test/java/synapticloop/b2/request/B2GetUploadUrlRequestTest.java
+++ b/src/test/java/synapticloop/b2/request/B2GetUploadUrlRequestTest.java
@@ -13,7 +13,7 @@ import synapticloop.b2.response.B2GetUploadUrlResponse;
 public class B2GetUploadUrlRequestTest {
 
 	@Test
-	public void testGetUploadUrl() throws B2ApiException {
+	public void testGetUploadUrl() throws Exception {
 		B2BucketResponse privateBucket = B2TestHelper.createRandomPrivateBucket();
 
 		B2GetUploadUrlResponse response = new B2GetUploadUrlRequest(HttpClients.createDefault(), B2TestHelper.getB2AuthorizeAccountResponse(), privateBucket.getBucketId()).getResponse();

--- a/src/test/java/synapticloop/b2/request/B2HeadFileRequestTest.java
+++ b/src/test/java/synapticloop/b2/request/B2HeadFileRequestTest.java
@@ -17,7 +17,7 @@ import synapticloop.b2.response.B2FileResponse;
 public class B2HeadFileRequestTest {
 
 	@Test
-	public void testHeadFileById() throws B2ApiException, IOException {
+	public void testHeadFileById() throws Exception {
 		final B2BucketResponse randomPrivateBucket = B2TestHelper.createRandomPrivateBucket();
 
 		Map<String, String> fileInfo = new HashMap<String, String>();

--- a/src/test/java/synapticloop/b2/request/B2HideFileRequestTest.java
+++ b/src/test/java/synapticloop/b2/request/B2HideFileRequestTest.java
@@ -26,7 +26,7 @@ public class B2HideFileRequestTest {
 	}
 
 	@Test
-	public void testHideFileWithPath() throws B2ApiException {
+	public void testHideFileWithPath() throws Exception {
 		randomPrivateBucket = B2TestHelper.createRandomPrivateBucket();
 		String bucketId = randomPrivateBucket.getBucketId();
 		b2FileResponseWithPath = B2TestHelper.uploadTemporaryFileToBucket(bucketId);
@@ -53,7 +53,7 @@ public class B2HideFileRequestTest {
 	}
 
 	@After
-	public void tearDown() throws B2ApiException {
+	public void tearDown() throws Exception {
 		B2TestHelper.deleteFile(b2HideFileResponse.getFileName(), b2HideFileResponse.getFileId());
 		B2TestHelper.deleteFile(b2FileResponseWithPath.getFileName(), b2FileResponseWithPath.getFileId());
 		B2TestHelper.deleteBucket(randomPrivateBucket.getBucketId());

--- a/src/test/java/synapticloop/b2/request/B2ListBucketsRequestTest.java
+++ b/src/test/java/synapticloop/b2/request/B2ListBucketsRequestTest.java
@@ -2,6 +2,7 @@ package synapticloop.b2.request;
 
 import static org.junit.Assert.*;
 
+import java.io.IOException;
 import java.util.List;
 
 import org.apache.http.impl.client.HttpClients;
@@ -19,12 +20,12 @@ public class B2ListBucketsRequestTest {
 	private B2AuthorizeAccountResponse b2AuthorizeAccountResponse = null;
 
 	@Before
-	public void setup() throws B2ApiException {
+	public void setup() throws Exception {
 		b2AuthorizeAccountResponse = B2TestHelper.getB2AuthorizeAccountResponse();
 	}
 
 	@Test
-	public void testListBuckets() throws B2ApiException {
+	public void testListBuckets() throws Exception {
 		// first we want to create a bucker
 		B2BucketResponse createRandomPrivateBucket = B2TestHelper.createRandomPrivateBucket();
 		String bucketName = createRandomPrivateBucket.getBucketName();

--- a/src/test/java/synapticloop/b2/request/B2ListFileNamesRequestTest.java
+++ b/src/test/java/synapticloop/b2/request/B2ListFileNamesRequestTest.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertNull;
 public class B2ListFileNamesRequestTest {
 
 	@Test
-	public void testListEmptyBucket() throws B2ApiException {
+	public void testListEmptyBucket() throws Exception {
 		B2AuthorizeAccountResponse b2AuthorizeAccountResponse = B2TestHelper.getB2AuthorizeAccountResponse();
 		B2BucketResponse b2BucketResponse = B2TestHelper.createRandomPrivateBucket();
 

--- a/src/test/java/synapticloop/b2/request/B2ListFileVersionsRequestTest.java
+++ b/src/test/java/synapticloop/b2/request/B2ListFileVersionsRequestTest.java
@@ -27,7 +27,7 @@ public class B2ListFileVersionsRequestTest {
 	private static String bucketId = null;
 
 	@BeforeClass
-	public static void setupBeforeClass() throws B2ApiException {
+	public static void setupBeforeClass() throws Exception {
 		b2AuthorizeAccountResponse = B2TestHelper.getB2AuthorizeAccountResponse();
 		B2BucketResponse randomPrivateBucket = B2TestHelper.createRandomPrivateBucket();
 		bucketId = randomPrivateBucket.getBucketId();
@@ -38,14 +38,14 @@ public class B2ListFileVersionsRequestTest {
 	}
 
 	@Test
-	public void listFileVersions() throws B2ApiException {
+	public void listFileVersions() throws Exception {
 		B2ListFilesResponse b2ListFileVersionsResponse = new B2ListFileVersionsRequest(HttpClients.createDefault(), b2AuthorizeAccountResponse, bucketId, 1000).getResponse();
 		List<B2FileInfoResponse> files = b2ListFileVersionsResponse.getFiles();
 		assertEquals(4, files.size());
 	}
 
 	@Test
-	public void listFileVersionByName() throws B2ApiException {
+	public void listFileVersionByName() throws Exception {
 		B2ListFilesResponse b2ListFileVersionsResponse = new B2ListFileVersionsRequest(HttpClients.createDefault(), b2AuthorizeAccountResponse, bucketId, 1, tempFileOne.getFileName(), null).getResponse();
 		List<B2FileInfoResponse> files = b2ListFileVersionsResponse.getFiles();
 		assertEquals(1, files.size());
@@ -55,7 +55,7 @@ public class B2ListFileVersionsRequestTest {
 	}
 
 	@Test
-	public void listFileVersionByNameAndId() throws B2ApiException {
+	public void listFileVersionByNameAndId() throws Exception {
 		B2ListFilesResponse b2ListFileVersionsResponse = new B2ListFileVersionsRequest(HttpClients.createDefault(),  b2AuthorizeAccountResponse, bucketId, 1, tempFileTwo.getFileName(), tempFileTwo.getFileId()).getResponse();
 		List<B2FileInfoResponse> files = b2ListFileVersionsResponse.getFiles();
 		assertEquals(1, files.size());
@@ -65,7 +65,7 @@ public class B2ListFileVersionsRequestTest {
 	}
 
 	@Test(expected = B2ApiException.class)
-	public void listFileVersionIncorrect() throws B2ApiException {
+	public void listFileVersionIncorrect() throws Exception {
 		B2ListFilesResponse b2ListFileVersionsResponse = new B2ListFileVersionsRequest(HttpClients.createDefault(), b2AuthorizeAccountResponse, bucketId, 1, null, tempFileTwo.getFileId()).getResponse();
 		List<B2FileInfoResponse> files = b2ListFileVersionsResponse.getFiles();
 		assertEquals(1, files.size());
@@ -76,7 +76,7 @@ public class B2ListFileVersionsRequestTest {
 	}
 
 	@Test
-	public void listFiles() throws B2ApiException {
+	public void listFiles() throws Exception {
 		CloseableHttpClient client = HttpClients.createDefault();
 		B2ListFilesResponse b2ListFileVersionsResponse = new B2ListFileVersionsRequest(client, b2AuthorizeAccountResponse, bucketId, 1, tempFileOne.getFileName(), null).getResponse();
 		assertEquals(1, b2ListFileVersionsResponse.getFiles().size());
@@ -92,7 +92,7 @@ public class B2ListFileVersionsRequestTest {
 	}
 
 	@AfterClass
-	public static void tearDownAfterClass() throws B2ApiException {
+	public static void tearDownAfterClass() throws Exception {
 		CloseableHttpClient client = HttpClients.createDefault();
 		new B2DeleteFileVersionRequest(client, b2AuthorizeAccountResponse, tempFileOne.getFileName(), tempFileOne.getFileId()).getResponse();
 		new B2DeleteFileVersionRequest(client, b2AuthorizeAccountResponse, tempFileTwo.getFileName(), tempFileTwo.getFileId()).getResponse();

--- a/src/test/java/synapticloop/b2/request/B2UpdateBucketRequestTest.java
+++ b/src/test/java/synapticloop/b2/request/B2UpdateBucketRequestTest.java
@@ -15,7 +15,7 @@ import synapticloop.b2.response.B2BucketResponse;
 public class B2UpdateBucketRequestTest {
 
 	@Test
-	public void testUpdateBucket() throws B2ApiException {
+	public void testUpdateBucket() throws Exception {
 		B2AuthorizeAccountResponse b2AuthorizeAccountResponse = B2TestHelper.getB2AuthorizeAccountResponse();
 
 		B2BucketResponse privateBucket = B2TestHelper.createRandomPrivateBucket();


### PR DESCRIPTION
Make sure clients can differentiate between API and I/O failures. B2ApiException is always a server error with a JSON error response.